### PR TITLE
Add makefile (and ignore the resulting binary in git)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-cmd/artoo/artoo
+artoo
 artoo.toml
 scratch/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+GO ?= go
+GOFLAGS ?= -tags netgo
+
+all: artoo
+
+artoo:
+	$(GO) build $(GOFLAGS) -o $@ cmd/artoo/main.go
+clean:
+	rm -f artoo
+
+.PHONY: all artoo


### PR DESCRIPTION
In the future we may want to add more to `GOFLAGS`, but for now avoiding cgo via `-tags netgo` is sufficient.