### PR TITLE
style: add remaining named colors and styles

### DIFF
--- a/style/style.go
+++ b/style/style.go
@@ -1,8 +1,33 @@
 package style
 
+// https://modern.ircdocs.horse/formatting.html
+
 var (
-	Reset   = "\x0f"
-	Italics = "\x1d"
-	Color   = "\x03"
-	Grey    = "14"
+	Reset         = "\x0f"
+	Bold          = "\x02"
+	Italics       = "\x1d"
+	Underline     = "\x1f"
+	Strikethrough = "\x1e"
+	Monospace     = "\x11"
+	Color         = "\x03"
+	HexColor      = "\x04"
+	ReverseColor  = "\x16"
+
+	White        = "00"
+	Black        = "01"
+	Blue         = "02"
+	Green        = "03"
+	Red          = "04"
+	Brown        = "05"
+	Magenta      = "06"
+	Orange       = "07"
+	Yellow       = "08"
+	LightGreen   = "09"
+	Cyan         = "10"
+	LightCyan    = "11"
+	LightBlue    = "12"
+	Pink         = "13"
+	Grey         = "14"
+	LightGrey    = "15"
+	DefaultColor = "99"
 )


### PR DESCRIPTION
The major colors and styles from https://modern.ircdocs.horse/formatting.html are now implemented as constants. Not much else left to do for the style package now, if anything.