### PR TITLE
set a more conservative IRC maximum message length

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tfaughnan/artoo/config"
 )
 
-var IrcMaxBytes = 512
+var IrcMaxBytes = 400
 
 type LineHandler func(lgroups map[string]string)
 


### PR DESCRIPTION
IRC message lengths include the hostmask, which is hard to determine with 100% accuracy

a robust and simple fix is to simply set the maximum length to a conservative value of around 400